### PR TITLE
Fix syntax error in AnonClassMovedMethod.java

### DIFF
--- a/left/SimpleTests/AnonClassMovedMethod.java
+++ b/left/SimpleTests/AnonClassMovedMethod.java
@@ -30,6 +30,6 @@ public class AnonClassMovedMethod {
             public void mouseExited(MouseEvent e) {
                 System.out.println("Mouse Exited!");
             }
-        }
+        };
     }
 }

--- a/results/linebased/SimpleTests/AnonClassMovedMethod.java
+++ b/results/linebased/SimpleTests/AnonClassMovedMethod.java
@@ -46,6 +46,6 @@ public class AnonClassMovedMethod {
             public void mouseExited(MouseEvent e) {
                 System.out.println("Mouse Exited!");
             }
-        }
+        };
     }
 }

--- a/results/semistructured/SimpleTests/AnonClassMovedMethod.java
+++ b/results/semistructured/SimpleTests/AnonClassMovedMethod.java
@@ -45,6 +45,6 @@ public class AnonClassMovedMethod {
             public void mouseExited(MouseEvent e) {
                 System.out.println("Mouse Exited!");
             }
-        }
+        };
   }
 }

--- a/right/SimpleTests/AnonClassMovedMethod.java
+++ b/right/SimpleTests/AnonClassMovedMethod.java
@@ -30,6 +30,6 @@ public class AnonClassMovedMethod {
             public void mouseExited(MouseEvent e) {
                 System.out.println("Mouse Exited!");
             }
-        }
+        };
     }
 }


### PR DESCRIPTION
With fixes/check_parse_errors, JDime detects this syntax error and refuses to merge.